### PR TITLE
Fix poor behaviour fetching old messages

### DIFF
--- a/src/Blazor.Gitter.Core/Components/Shared/RoomMessages.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomMessages.razor.cs
@@ -103,32 +103,32 @@ namespace Blazor.Gitter.Core.Components.Shared
 
         internal async Task MessagesScrolled(UIEventArgs args)
         {
-            if (!NoMoreOldMessages && !IsFetchingOlder && Messages.Any())
+            if (!NoMoreOldMessages && Messages.Any())
             {
-                await ssScroll.WaitAsync();
-                try
+                if (await ssScroll.WaitAsync(0))
                 {
-                    var scroll = await JSRuntime.GetScrollTop("blgmessagelist");
-                    if (scroll < 100)
+                    try
                     {
-                        IsFetchingOlder = true;
-
-                        var count = await FetchOldMessages(tokenSource.Token);
-                        if (count == 0)
+                        State.RecordActivity();
+                        var scroll = await JSRuntime.GetScrollTop("blgmessagelist");
+                        if (scroll < 100)
                         {
-                            NoMoreOldMessages = true;
+
+                            var count = await FetchOldMessages(tokenSource.Token);
+                            if (count == 0)
+                            {
+                                NoMoreOldMessages = true;
+                            }
                         }
-                        IsFetchingOlder = false;
+                    }
+                    catch
+                    {
+                    }
+                    finally
+                    {
+                        ssScroll.Release();
                     }
                 }
-                catch
-                {
-                }
-                finally
-                {
-                    ssScroll.Release();
-                }
-                State.RecordActivity();
             }
         }
 
@@ -216,12 +216,12 @@ namespace Blazor.Gitter.Core.Components.Shared
         {
             var options = GitterApi.GetNewOptions();
             options.Lang = Localisation.LocalCultureInfo.Name;
-            if (!token.IsCancellationRequested && IsFetchingOlder)
+            options.AfterId = "";
+            if (Messages?.Any() ?? false)
             {
-                options.AfterId = "";
-                if (Messages?.Any() ?? false)
+                options.BeforeId = GetFirstMessageId();
+                if (!token.IsCancellationRequested)
                 {
-                    options.BeforeId = GetFirstMessageId();
                     var count = await FetchNewMessages(options, token);
                     await Invoke(StateHasChanged);
                     await Task.Delay(100);


### PR DESCRIPTION
When scrolling there can be a lot of events firing, which is why I used a SemaphoreSlim to prevent multiple fetches - I just hadn't written it right, so it was trying to release when it shouldn't.