### PR TITLE
OAuth Api support.

### DIFF
--- a/src/Blazor.Gitter.Client/Startup.cs
+++ b/src/Blazor.Gitter.Client/Startup.cs
@@ -13,6 +13,7 @@ namespace Blazor.Gitter.Client
         public void ConfigureServices(IServiceCollection services)
         {                   
             services.AddSingleton<HttpClient>((s) => new HttpClient())
+                .AddSingleton<IAuthApi, GitterAuthApi>()
                 .AddSingleton<IChatApi, GitterApi>()
                 .AddSingleton<ILocalStorageService, LocalStorageService>()
                 .AddSingleton<ILocalisationHelper, LocalisationHelper>()

--- a/src/Blazor.Gitter.Library/Model/GitterAccessToken.cs
+++ b/src/Blazor.Gitter.Library/Model/GitterAccessToken.cs
@@ -1,0 +1,7 @@
+﻿namespace Blazor.Gitter.Library
+{
+    public class GitterAccessToken : IAccessToken
+    {
+        public string Access_Token { get; set; }
+    }
+}

--- a/src/Blazor.Gitter.Library/Model/IAccessToken.cs
+++ b/src/Blazor.Gitter.Library/Model/IAccessToken.cs
@@ -1,0 +1,7 @@
+﻿namespace Blazor.Gitter.Library
+{
+    public interface IAccessToken
+    {
+        string Access_Token { get; set; }
+    }
+}

--- a/src/Blazor.Gitter.Library/Model/IAuthApi.cs
+++ b/src/Blazor.Gitter.Library/Model/IAuthApi.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Blazor.Gitter.Library
+{
+    public interface IAuthApi
+    {
+        string GetLoginUrl();
+        Task<string> GetAccessToken(string exchangeToken);
+    }
+}

--- a/src/Blazor.Gitter.Library/Services/GitterAuthApi.cs
+++ b/src/Blazor.Gitter.Library/Services/GitterAuthApi.cs
@@ -1,0 +1,64 @@
+﻿using Microsoft.AspNetCore.Components;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+
+namespace Blazor.Gitter.Library
+{
+    public class GitterAuthApi : IAuthApi
+    {
+        private const string APIBASE = "http://gitter.im/login/oauth/";
+
+        private const string OAUTHKEY = "";
+        private const string OAUTHSECRET = "";
+        private const string REDIRECTURI = "http://localhost:57226/";
+
+        private string Token { get; set; }
+        private HttpClient HttpClient { get; set; }
+        public GitterAuthApi(HttpClient httpClient = null)
+        {
+            HttpClient = httpClient ?? throw new Exception("Make sure you have added an HttpClient to your DI Container");
+        }
+
+        public async Task<string> GetAccessToken(string exchangeToken)
+        {
+            PrepareHttpClient();
+
+            var result = await HttpClient.PostJsonAsync<GitterAccessToken>(
+                String.Format("{0}token",
+               APIBASE 
+               ), new
+                {
+                    code = exchangeToken,
+                    client_id = OAUTHKEY,
+                    client_secret = OAUTHSECRET,
+                    redirect_uri = REDIRECTURI,
+                    grant_type = "authorization_code"
+                });
+
+            return null;
+        }
+
+        private void PrepareHttpClient()
+        {
+            if (!(HttpClient.BaseAddress is object))
+            {
+                HttpClient.BaseAddress = new Uri(APIBASE);
+                HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            }
+        }
+
+        public string GetLoginUrl()
+        {
+            return String.Format("{0}authorize?redirect_uri={1}&response_type={2}&client_id={3}",
+               APIBASE,
+               "http://localhost:57226/",  //redirect_uri
+               "code",                     //response_type
+               OAUTHKEY                    //client_id
+               );
+        }
+    }
+}

--- a/src/Blazor.Gitter.Server/Startup.cs
+++ b/src/Blazor.Gitter.Server/Startup.cs
@@ -20,6 +20,7 @@ namespace Blazor.Gitter.Server
             services.AddServerSideBlazor();
             services.AddScoped<HttpClient>((s) => new HttpClient())
                 .AddScoped<IChatApi, GitterApi>()
+                .AddSingleton<IAuthApi, GitterAuthApi>()
                 .AddScoped<ILocalStorageService, LocalStorageService>()
                 .AddScoped<ILocalisationHelper, LocalisationHelper>()
                 .AddScoped<IAppState, AppState>();


### PR DESCRIPTION
This is the backend part that I mentioned in #3 .

To work, it's needed first create an app in [developer.gitter.im](https://developer.gitter.im). So, the variables OAUTHKEY and OAUTHSECRET must be added with the keys provided by the website.

- GetLoginUrl() - The first part of the flow, it gives the URL where the user will authorize the app. The Gitter website will redirect back later.
- GetAccessToken(string exchangeToken) - Exchange the code when returned from the Gitter website and take the "final" access token.