### PR TITLE
Decouple Blazor.Gitter.Library

### DIFF
--- a/Blazored.Gitter.sln
+++ b/Blazored.Gitter.sln
@@ -16,7 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		azure-pipelines.yml = azure-pipelines.yml
 		src\Directory.Build.props = src\Directory.Build.props
-		src\README.md = src\README.md
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global

--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ Of course, this is your own personal token - don't share it.
 Once you are up and running, take a look at the issues list and see if you can help.
 
 **Note** There is currently an issue with a couple of Gitter APIs that don't work in a purely client-based application like this. The streaming API is one, so we have to poll for new messages. The other is Authentication, which is why, for now at least, we are using personal tokens. 
+
+### Projects
+
+Blazored Gitter consists of four projects:
+
+* **Blazor.Gitter.Library** is a C# API client for the gitter API.
+* **Blazor.Gitter.Client** and **Blazor.Gitter.Server** are the Blazor WebAssembly and Blazor Server front-ends, respectively.
+* **Blazor.Gitter.Core** contains the Razor components for the UI, as well as other code that is shared between the Client and Server projects.

--- a/src/Blazor.Gitter.Client/Program.cs
+++ b/src/Blazor.Gitter.Client/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Blazor.Gitter.Core;
 using Blazor.Gitter.Core.Components;
 using Blazor.Gitter.Core.Components.Shared;
 using Blazor.Gitter.Library;

--- a/src/Blazor.Gitter.Core/Blazor.Gitter.Core.csproj
+++ b/src/Blazor.Gitter.Core/Blazor.Gitter.Core.csproj
@@ -87,6 +87,9 @@
     <ProjectReference Include="..\Blazor.Gitter.Library\Blazor.Gitter.Library.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Services\" />
+  </ItemGroup>
   <Target Name="PreBuildTask" BeforeTargets="BeforeBuild">
     <Exec Command="npm install" />
     <Exec Command="npm run build" />

--- a/src/Blazor.Gitter.Core/Services/ILocalisationHelper.cs
+++ b/src/Blazor.Gitter.Core/Services/ILocalisationHelper.cs
@@ -2,7 +2,7 @@
 using System.Globalization;
 using System.Threading.Tasks;
 
-namespace Blazor.Gitter.Library
+namespace Blazor.Gitter.Core
 {
     public interface ILocalisationHelper
     {

--- a/src/Blazor.Gitter.Core/Services/LocalisationHelper.cs
+++ b/src/Blazor.Gitter.Core/Services/LocalisationHelper.cs
@@ -3,7 +3,7 @@ using System;
 using System.Globalization;
 using System.Threading.Tasks;
 
-namespace Blazor.Gitter.Library
+namespace Blazor.Gitter.Core
 {
     public class LocalisationHelper : ILocalisationHelper
     {

--- a/src/Blazor.Gitter.Library/Blazor.Gitter.Library.csproj
+++ b/src/Blazor.Gitter.Library/Blazor.Gitter.Library.csproj
@@ -15,10 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BlazorComponentUtilities" Version="1.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Blazor.HttpClient" Version="3.2.0-preview2.20160.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.2" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Blazor.Gitter.Server/Startup.cs
+++ b/src/Blazor.Gitter.Server/Startup.cs
@@ -1,3 +1,4 @@
+using Blazor.Gitter.Core;
 using Blazor.Gitter.Core.Components.Shared;
 using Blazor.Gitter.Library;
 using Blazored.LocalStorage;


### PR DESCRIPTION
Make it more feasible to release Blazor.Gitter.Library as a standalone API client library without Blazor-specific dependencies.

Once #74 is merged, we can also remove the dependency on `Microsoft.AspNetCore.Blazor.HttpClient`.