### PR TITLE
Username autocompletion

### DIFF
--- a/src/Blazor.Gitter.Client/Program.cs
+++ b/src/Blazor.Gitter.Client/Program.cs
@@ -5,6 +5,7 @@ using Blazor.Gitter.Core;
 using Blazor.Gitter.Core.Components;
 using Blazor.Gitter.Core.Components.Shared;
 using Blazor.Gitter.Library;
+using Blazor.Gitter.Library.Services;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +21,7 @@ namespace Blazor.Gitter.Client
                 .AddSingleton<IChatApi, GitterApi>()
                 .AddSingleton<ILocalStorageService, LocalStorageService>()
                 .AddSingleton<ILocalisationHelper, LocalisationHelper>()
+                .AddSingleton<RoomUsersRepository>()
                 .AddSingleton<IAppState, AppState>();
             builder.RootComponents.Add<App>("app");
 

--- a/src/Blazor.Gitter.Core/Components/Pages/Room.razor
+++ b/src/Blazor.Gitter.Core/Components/Pages/Room.razor
@@ -24,5 +24,8 @@ else
         <aside class="chat-room__search @SearchCss">
             <RoomSearch ChatRoom="@ThisRoom" UserId="@State.GetMyUser().Id" />
         </aside>
+
+        <!-- FIXME: technically needs to be positioned inside RoomMessages -->
+        <RoomUserSearchResults />
     </div>
 }

--- a/src/Blazor.Gitter.Core/Components/Shared/AppState.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/AppState.cs
@@ -76,6 +76,9 @@ namespace Blazor.Gitter.Core.Components.Shared
         /// </summary>
         public event EventHandler SearchMenuToggled;
 
+        public event EventHandler RoomUserSearchCancelled;
+        public event EventHandler<IEnumerable<IChatUser>> RoomUserSearchPerformed;
+
         public AppState(
             ILocalStorageService localStorage,
             ILocalisationHelper localisationHelper,
@@ -186,6 +189,15 @@ namespace Blazor.Gitter.Core.Components.Shared
         public void ToggleSearchMenu()
         {
             SearchMenuToggled?.Invoke(this, null);
+        }
+
+        public void CancelRoomUserSearch()
+        {
+            RoomUserSearchCancelled?.Invoke(this, null);
+        }
+        public void ShowRoomUserSearchResults(IEnumerable<IChatUser> results)
+        {
+            RoomUserSearchPerformed?.Invoke(this, results);
         }
 
         public bool HasApiKey => !string.IsNullOrWhiteSpace(apiKey);

--- a/src/Blazor.Gitter.Core/Components/Shared/IAppState.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/IAppState.cs
@@ -19,12 +19,16 @@ namespace Blazor.Gitter.Core.Components.Shared
         event EventHandler<IChatMessage> GotMessageUpdate;
         event EventHandler MenuToggled;
         event EventHandler SearchMenuToggled;
+        event EventHandler RoomUserSearchCancelled;
+        event EventHandler<IEnumerable<IChatUser>> RoomUserSearchPerformed;
         bool HasApiKey { get; }
         bool HasChatRooms { get; }
         bool HasChatUser { get; }
         bool Initialised { get; }
         void ToggleMenu();
         void ToggleSearchMenu();
+        void CancelRoomUserSearch();
+        void ShowRoomUserSearchResults(IEnumerable<IChatUser> results);
         string GetApiKey();
         List<IChatRoom> GetMyRooms();
         IChatRoom GetRoom(string RoomId);

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomMessages.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomMessages.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Blazor.Gitter.Core.Browser;
 using Blazor.Gitter.Library;
+using Blazor.Gitter.Library.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using System;
@@ -16,6 +17,7 @@ namespace Blazor.Gitter.Core.Components.Shared
         [Inject] IChatApi GitterApi { get; set; }
         [Inject] ILocalisationHelper Localisation { get; set; }
         [Inject] IAppState State { get; set; }
+        [Inject] RoomUsersRepository RoomUsersRepository { get; set; } // maybe inject this per-room?
 
         [Parameter] public IChatRoom ChatRoom { get; set; }
         [Parameter] public string UserId { get; set; }
@@ -50,7 +52,7 @@ namespace Blazor.Gitter.Core.Components.Shared
 
         private void GotMessageUpdate(object sender, IChatMessage message)
         {
-            if (ssFetch.Wait(-1,tokenSource.Token))
+            if (ssFetch.Wait(-1, tokenSource.Token))
             {
                 try
                 {
@@ -63,7 +65,7 @@ namespace Blazor.Gitter.Core.Components.Shared
                 }
                 finally
                 {
-                    ssFetch.Release();   
+                    ssFetch.Release();
                 }
             }
         }
@@ -81,7 +83,7 @@ namespace Blazor.Gitter.Core.Components.Shared
                 Paused = true;
                 InvokeAsync(StateHasChanged);
             }
-            catch 
+            catch
             {
             }
         }
@@ -219,7 +221,9 @@ namespace Blazor.Gitter.Core.Components.Shared
                         {
                             Messages.AddRange(RemoveDuplicates(Messages, messages));
                         }
-                        
+
+                        await RoomUsersRepository.AddOrUpdateRangeAsync(messages.Select(m => m.FromUser));
+
                         await InvokeAsync(StateHasChanged);
                         await Task.Delay(1);
                     }

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor
@@ -5,8 +5,8 @@
     <textarea id="@MessageInputId"
               rows="@Rows"
               class="@NewMessageClass"
-              @bind-value="NewMessage"
-              @bind-value:event="oninput"
+              value="@NewMessage"
+              @oninput="OnInput"
               @onkeydown="Shortcuts"
               placeholder="Ctrl-Enter to send..." />
     <button id="@OkButtonId" type="submit" class="chat-room__send-button" @onclick="SendMessage">Ok</button>

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
@@ -74,7 +74,6 @@ namespace Blazor.Gitter.Core.Components.Shared
             }
 
             // TODO:
-            // * display result in popup
             // * allow arrow up/down selection
 
             foreach (var item in chatRoomUsers)

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 #nullable enable
@@ -49,6 +50,7 @@ namespace Blazor.Gitter.Core.Components.Shared
         {
             if (!NewMessage.Contains("@"))
             {
+                State.CancelRoomUserSearch();
                 _IsShowingUsernameAutocomplete = false;
                 return;
             }
@@ -58,6 +60,15 @@ namespace Blazor.Gitter.Core.Components.Shared
             Console.WriteLine($"Should pop up! Will query: {query}");
 
             var chatRoomUsers = await RoomUsersRepository.QueryAsync(this.ChatRoom, query);
+
+            if (chatRoomUsers.Any())
+            {
+                State.ShowRoomUserSearchResults(chatRoomUsers);
+            }
+            else
+            {
+                State.CancelRoomUserSearch();
+            }
 
             // TODO:
             // * display result in popup

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
@@ -14,6 +14,8 @@ namespace Blazor.Gitter.Core.Components.Shared
         [Inject] IAppState State { get; set; }
         [Inject] IJSRuntime JSRuntime { get; set; }
 
+        [Inject] Library.Services.RoomUsersRepository RoomUsersRepository { get; set; }
+
         [Parameter] public IChatRoom ChatRoom { get; set; }
         [Parameter] public IChatUser User { get; set; }
         internal string NewMessage

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
@@ -48,7 +48,7 @@ namespace Blazor.Gitter.Core.Components.Shared
 
         private async Task QueryRoomUsersAsync()
         {
-            if (!NewMessage.Contains("@"))
+            if (!_IsShowingUsernameAutocomplete || !NewMessage.Contains("@"))
             {
                 State.CancelRoomUserSearch();
                 _IsShowingUsernameAutocomplete = false;
@@ -206,6 +206,8 @@ namespace Blazor.Gitter.Core.Components.Shared
 
                     case "Escape":
                         _IsShowingUsernameAutocomplete = false;
+                        State.CancelRoomUserSearch();
+
                         break;
                 }
 

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
@@ -29,6 +29,11 @@ namespace Blazor.Gitter.Core.Components.Shared
             }
         }
 
+        protected async Task OnInput(ChangeEventArgs e)
+        {
+            NewMessage = e.Value as string ?? "";
+        }
+
         private const string BaseClass = "chat-room__send-message";
         internal string NewMessageClass = BaseClass;
         internal string OkButtonId = "message-send-button";

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
@@ -59,6 +59,9 @@ namespace Blazor.Gitter.Core.Components.Shared
 
             Console.WriteLine($"Should pop up! Will query: {query}");
 
+            if (string.IsNullOrWhiteSpace(query))
+                return;
+
             var chatRoomUsers = await RoomUsersRepository.QueryAsync(this.ChatRoom, query);
 
             if (chatRoomUsers.Any())

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
@@ -125,6 +125,46 @@ namespace Blazor.Gitter.Core.Components.Shared
                         break;
                 }
             }
+            else
+            {
+                switch (args.Key)
+                {
+                    case "@":
+                        var selectionStart = await BrowserInterop.GetSelectionStart(JSRuntime, MessageInputId);
+
+                        Console.WriteLine($"Selection start: {selectionStart}");
+
+                        // the input field only contains '@', or there's whitespace next to our caret
+
+                        if (selectionStart < 0 ||
+                            NewMessage.Length == 1 ||
+                            (selectionStart == 0 && char.IsWhiteSpace(NewMessage[selectionStart + 1])) ||
+                            (selectionStart == NewMessage.Length && char.IsWhiteSpace(NewMessage[selectionStart - 1])))
+                        {
+                            string query = NewMessage.Substring(selectionStart);
+
+                            Console.WriteLine($"Should pop up! Will query: {query}");
+
+                            var chatRoomUsers = await RoomUsersRepository.QueryAsync(this.ChatRoom, query);
+
+                            // TODO:
+                            // * display result in popup
+                            // * allow arrow up/down selection
+
+                            foreach (var item in chatRoomUsers)
+                            {
+                                Console.WriteLine(item.DisplayName);
+                            }
+                        }
+                        break;
+
+                    case "Escape":
+                        // TODO: close popup
+
+                        break;
+                }
+
+            }
             return;
         }
         public void Dispose()

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomSend.razor.cs
@@ -18,6 +18,8 @@ namespace Blazor.Gitter.Core.Components.Shared
 
         [Parameter] public IChatRoom ChatRoom { get; set; }
         [Parameter] public IChatUser User { get; set; }
+
+        private string newMessage = "";
         internal string NewMessage
         {
             get => newMessage;
@@ -28,7 +30,6 @@ namespace Blazor.Gitter.Core.Components.Shared
         }
 
         private const string BaseClass = "chat-room__send-message";
-        private string newMessage;
         internal string NewMessageClass = BaseClass;
         internal string OkButtonId = "message-send-button";
         internal string MessageInputId = "message-send-input";

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor
@@ -1,0 +1,11 @@
+﻿@inherits RoomUserSearchResultsBase
+
+@if (IsVisible)
+{
+    <div class="chat-room__roomusersearchresults">
+        @foreach (var item in Results)
+        {
+            <p>@item.DisplayName <small>@item.Username</small></p>
+        }
+    </div>
+}

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor
@@ -5,7 +5,7 @@
     <div class="chat-room__roomusersearchresults">
         @foreach (var item in Results)
         {
-            <p>@item.DisplayName <small>@item.Username</small></p>
+            <div>@item.DisplayName <small>@@@item.Username</small></div>
         }
     </div>
 }

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor.cs
@@ -37,13 +37,13 @@ namespace Blazor.Gitter.Core.Components.Shared
 
         private async void SearchPerformed(object sender, IEnumerable<IChatUser> results)
         {
-            await BrowserInterop.RepositionRoomSearchResults(JSRuntime);
-
             Results = results;
 
             IsVisible = true;
 
             StateHasChanged();
+
+            await BrowserInterop.RepositionRoomSearchResults(JSRuntime);
         }
     }
 }

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor.cs
@@ -28,11 +28,11 @@ namespace Blazor.Gitter.Core.Components.Shared
             State.RoomUserSearchPerformed += SearchPerformed;
         }
 
-        private void SearchCancelled(object sender, EventArgs e)
+        private async void SearchCancelled(object sender, EventArgs e)
         {
             IsVisible = false;
 
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
 
         private async void SearchPerformed(object sender, IEnumerable<IChatUser> results)
@@ -41,7 +41,7 @@ namespace Blazor.Gitter.Core.Components.Shared
 
             IsVisible = true;
 
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
 
             await BrowserInterop.RepositionRoomSearchResults(JSRuntime);
         }

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomUserSearchResults.razor.cs
@@ -1,0 +1,49 @@
+﻿using Blazor.Gitter.Core.Browser;
+using Blazor.Gitter.Library;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+#nullable enable
+
+namespace Blazor.Gitter.Core.Components.Shared
+{
+    public class RoomUserSearchResultsBase : ComponentBase
+    {
+        [Inject] IAppState State { get; set; }
+        [Inject] IJSRuntime JSRuntime { get; set; }
+
+        protected IEnumerable<IChatUser> Results { get; set; } = Enumerable.Empty<IChatUser>();
+
+        protected bool IsVisible { get; set; }
+
+        protected override void OnInitialized()
+        {
+            base.OnInitialized();
+            State.RoomUserSearchCancelled += SearchCancelled;
+            State.RoomUserSearchPerformed += SearchPerformed;
+        }
+
+        private void SearchCancelled(object sender, EventArgs e)
+        {
+            IsVisible = false;
+
+            StateHasChanged();
+        }
+
+        private async void SearchPerformed(object sender, IEnumerable<IChatUser> results)
+        {
+            await BrowserInterop.RepositionRoomSearchResults(JSRuntime);
+
+            Results = results;
+
+            IsVisible = true;
+
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Blazor.Gitter.Core/Services/DebounceHelper.cs
+++ b/src/Blazor.Gitter.Core/Services/DebounceHelper.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Blazor.Gitter.Core
+{
+    public class DebounceHelper
+    {
+        private CancellationTokenSource debounceToken = null;
+
+        public async Task DebounceAsync(Func<CancellationToken, Task> func, int delayMilliseconds = 1000)
+        {
+            // https://stackoverflow.com/a/62196612/
+
+            // Cancel previous task
+            if (debounceToken != null) { debounceToken.Cancel(); }
+
+            // Assign new token
+            debounceToken = new CancellationTokenSource();
+
+            await Task.Delay(delayMilliseconds, debounceToken.Token);
+
+            if (debounceToken.IsCancellationRequested)
+                return;
+
+            await func(debounceToken.Token);
+        }
+    }
+}

--- a/src/Blazor.Gitter.Core/browser/BrowserInterop.cs
+++ b/src/Blazor.Gitter.Core/browser/BrowserInterop.cs
@@ -7,9 +7,14 @@ namespace Blazor.Gitter.Core.Browser
 {
     static class BrowserInterop
     {
+        public static ValueTask<int> GetSelectionStart(this IJSRuntime JSRuntime, string id)
+        {
+            return JSRuntime.InvokeAsync<int>("chat.getSelectionStart", id);
+        }
+
         public static ValueTask<double> GetScrollTop(this IJSRuntime JSRuntime, string id)
         {
-            return JSRuntime.InvokeAsync<double>("chat.getScrollTop",id);
+            return JSRuntime.InvokeAsync<double>("chat.getScrollTop", id);
         }
         public static ValueTask<bool> IsScrolledToBottom(this IJSRuntime JSRuntime, string id)
         {
@@ -27,7 +32,7 @@ namespace Blazor.Gitter.Core.Browser
         {
             return JSRuntime.InvokeAsync<bool>("chat.scrollIntoView", id);
         }
-        [Obsolete("Please use SetFocusById now as there is a bug in the JSInterop",true)]
+        [Obsolete("Please use SetFocusById now as there is a bug in the JSInterop", true)]
         public static ValueTask<bool> SetFocus(this IJSRuntime JSRuntime, ElementReference elementRef)
         {
             return JSRuntime.InvokeAsync<bool>("chat.setFocus", elementRef);

--- a/src/Blazor.Gitter.Core/browser/BrowserInterop.cs
+++ b/src/Blazor.Gitter.Core/browser/BrowserInterop.cs
@@ -7,6 +7,9 @@ namespace Blazor.Gitter.Core.Browser
 {
     static class BrowserInterop
     {
+        public static ValueTask RepositionRoomSearchResults(this IJSRuntime jsRuntime)
+            => jsRuntime.InvokeVoidAsync("chat.repositionRoomSearchResults");
+
         public static ValueTask<int> GetSelectionStart(this IJSRuntime JSRuntime, string id)
         {
             return JSRuntime.InvokeAsync<int>("chat.getSelectionStart", id);

--- a/src/Blazor.Gitter.Core/content/css/_chatroom.scss
+++ b/src/Blazor.Gitter.Core/content/css/_chatroom.scss
@@ -315,3 +315,12 @@
     font-style: italic;
 }
 
+.chat-room__roomusersearchresults {
+    position: absolute;
+    z-index: 2;
+    bottom: 0;
+    padding: 1em;
+    height: 300px;
+    width: 300px;
+    background-color: $background-lighter;
+}

--- a/src/Blazor.Gitter.Core/content/css/_chatroom.scss
+++ b/src/Blazor.Gitter.Core/content/css/_chatroom.scss
@@ -320,7 +320,6 @@
     z-index: 2;
     bottom: 0;
     padding: 1em;
-    height: 300px;
     width: 300px;
     background-color: $background-lighter;
 }

--- a/src/Blazor.Gitter.Core/content/scripts/chat.ts
+++ b/src/Blazor.Gitter.Core/content/scripts/chat.ts
@@ -7,12 +7,13 @@
 
         const resultsPopup = document.querySelector(".chat-room__roomusersearchresults") as HTMLElement;
 
-        // CHECK: doesn't work right yet
         if (resultsPopup == null)
             return;
 
-        resultsPopup.style.left = resultsIndex.toString();
-        resultsPopup.style.bottom = input.style.height;
+        // TODO: position horizontally
+        //resultsPopup.style.left = window.pageXOffset;
+
+        resultsPopup.style.bottom = `${input.clientHeight}px`;
     },
     getSelectionStart: function (id: string) {
         const el = document.getElementById(id) as HTMLInputElement;

--- a/src/Blazor.Gitter.Core/content/scripts/chat.ts
+++ b/src/Blazor.Gitter.Core/content/scripts/chat.ts
@@ -1,4 +1,15 @@
 ﻿(<any>window).chat = {
+    getSelectionStart: function (id: string) {
+        const el = document.getElementById(id) as HTMLInputElement;
+        try {
+            if (el) {
+                return el.selectionStart;
+            }
+        }
+        catch { }
+
+        return -1;
+    },
     getScrollTop: function (id: string) {
         const el = document.getElementById(id);
         try {

--- a/src/Blazor.Gitter.Core/content/scripts/chat.ts
+++ b/src/Blazor.Gitter.Core/content/scripts/chat.ts
@@ -1,4 +1,19 @@
 ﻿(<any>window).chat = {
+    repositionRoomSearchResults: function () {
+        const input = document.querySelector("#message-send-input") as HTMLInputElement;
+
+        // TODO: get the @ that's nearest to getSelectionStart
+        const resultsIndex = input.value.indexOf("@") + 1;
+
+        const resultsPopup = document.querySelector(".chat-room__roomusersearchresults") as HTMLElement;
+
+        // CHECK: doesn't work right yet
+        if (resultsPopup == null)
+            return;
+
+        resultsPopup.style.left = resultsIndex.toString();
+        resultsPopup.style.bottom = input.style.height;
+    },
     getSelectionStart: function (id: string) {
         const el = document.getElementById(id) as HTMLInputElement;
         try {

--- a/src/Blazor.Gitter.Library/Blazor.Gitter.Library.csproj
+++ b/src/Blazor.Gitter.Library/Blazor.Gitter.Library.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="5.0.0-preview.4.20251.6" />
   </ItemGroup>
 
 </Project>

--- a/src/Blazor.Gitter.Library/Services/RoomUsersRepository.cs
+++ b/src/Blazor.Gitter.Library/Services/RoomUsersRepository.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Blazor.Gitter.Library.Services
+{
+    public abstract class CachedRepository<T>
+    {
+        MemoryCache _Cache;
+
+        public CachedRepository()
+        {
+            _Cache = new MemoryCache(new MemoryCacheOptions());
+        }
+
+        protected abstract string _MakeKey(T item);
+
+        public async Task AddOrUpdateRangeAsync(IEnumerable<T> enumerable)
+        {
+            foreach (var item in enumerable)
+            {
+                await AddOrUpdateAsync(item);
+            }
+
+            Console.WriteLine($"User cache count: {_Cache.Count}");
+        }
+
+        private async Task AddOrUpdateAsync(T item)
+        {
+            await _Cache.GetOrCreateAsync(_MakeKey(item), entry =>
+            {
+                entry.SlidingExpiration = TimeSpan.FromMinutes(5);
+                return Task.FromResult(item);
+            });
+        }
+
+        protected IReadOnlyCollection<T> _GetCurrentEntries()
+        {
+            // UGLY: approaching this with reflection isn't great.
+
+            var field = typeof(MemoryCache).GetProperty("EntriesCollection", BindingFlags.NonPublic | BindingFlags.Instance);
+            var collection = field.GetValue(_Cache) as ICollection;
+
+            var entries = new List<T>();
+
+            PropertyInfo kvpValueProperty = null;
+
+            if (collection != null)
+                foreach (var item in collection)
+                {
+                    if (kvpValueProperty == null)
+                        kvpValueProperty = item.GetType().GetProperty("Value");
+
+                    // TODO MAYBE: return newest entries first?
+
+                    if ((kvpValueProperty.GetValue(item) as ICacheEntry)?.Value is T value)
+                        entries.Add(value);
+                }
+
+            return entries.AsReadOnly();
+        }
+    }
+
+    /// <summary>
+    /// Stores a local cache of known <see cref="IChatUser"/> instances. It gets
+    /// filled whenever new messages come in, users are queried, etc., and has a
+    /// sliding expiration.
+    ///
+    /// This is done mainly to work around
+    /// <see cref="GitterApi.GetChatRoomUsers(string)"/> being unreliable.
+    /// </summary>
+    public class RoomUsersRepository : CachedRepository<IChatUser>
+    {
+        private readonly IChatApi _GitterApi;
+
+        public RoomUsersRepository(IChatApi gitterApi)
+            => _GitterApi = gitterApi;
+
+        /// <summary>
+        /// Query the cache and the API (in turn adding to the cache) for a
+        /// user by partial <see cref="IChatUser.UserName" /> or
+        /// <see cref="IChatUser.DisplayName" />.
+        ///
+        /// If the query is empty, we just display some of the cache.
+        /// </summary>
+        /// <param name="onlyQueryTheCache">Skip querying the API</param>
+        public async Task<IEnumerable<IChatUser>> QueryAsync(IChatRoom room, string query, bool onlyQueryTheCache = false)
+        {
+            // BUG: room is actually ignored for cache. If you're in multiple
+            // rooms, this will suggest users who aren't here.
+
+            if (!onlyQueryTheCache && !(string.IsNullOrWhiteSpace(query)))
+            {
+                var users = await _GitterApi.GetChatRoomUsers(room.Id, new GitterRoomUserOptions { Query = query });
+
+                await AddOrUpdateRangeAsync(users);
+            }
+
+            return _GetCurrentEntries().Where(u => u.Username.Contains(query, StringComparison.OrdinalIgnoreCase) || u.DisplayName.Contains(query, StringComparison.OrdinalIgnoreCase));
+        }
+
+        protected override string _MakeKey(IChatUser item)
+            => $"User_{item.Id}";
+    }
+}

--- a/src/Blazor.Gitter.Server/Startup.cs
+++ b/src/Blazor.Gitter.Server/Startup.cs
@@ -1,6 +1,7 @@
 using Blazor.Gitter.Core;
 using Blazor.Gitter.Core.Components.Shared;
 using Blazor.Gitter.Library;
+using Blazor.Gitter.Library.Services;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components.Server;
@@ -31,6 +32,7 @@ namespace Blazor.Gitter.Server
                     .AddScoped<IChatApi, GitterApi>()
                     .AddScoped<ILocalStorageService, LocalStorageService>()
                     .AddScoped<ILocalisationHelper, LocalisationHelper>()
+                    .AddScoped<RoomUsersRepository>()
                     .AddScoped<IAppState, AppState>();
         }
 


### PR DESCRIPTION
Suggest users when typing `@` followed by part of a user name or display name.

Multiple aspects required:

* we need a UI like Gitter's own, or like in https://github.com/Blazored/Typeahead/ (but we can't outright use Typeahead, I believe, because it seems to always require a drop-down rather than being invoked inline from the message input box). Stuff like arrow up/down to select someone, etc.

* we need JS interop to get the cursor position (I think)

* we need the API-side search. Unlike Gitter's own client, this PR takes advantage of #75 so results are more comprehensive.