### PR TITLE
Replace Console.WriteLine with proper logging

### DIFF
--- a/src/Blazor.Gitter.Client/Blazor.Gitter.Client.csproj
+++ b/src/Blazor.Gitter.Client/Blazor.Gitter.Client.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+    <PackageReference Include="Blazor.Extensions.Logging" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Blazor.Gitter.Client/Program.cs
+++ b/src/Blazor.Gitter.Client/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Blazor.Extensions.Logging;
 using Blazor.Gitter.Core;
 using Blazor.Gitter.Core.Components;
 using Blazor.Gitter.Core.Components.Shared;
@@ -8,6 +9,7 @@ using Blazor.Gitter.Library;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Blazor.Gitter.Client
 {
@@ -16,11 +18,19 @@ namespace Blazor.Gitter.Client
         public static async Task Main(string[] args)
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
             builder.Services.AddSingleton(new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) })
                 .AddSingleton<IChatApi, GitterApi>()
                 .AddSingleton<ILocalStorageService, LocalStorageService>()
                 .AddSingleton<ILocalisationHelper, LocalisationHelper>()
                 .AddSingleton<IAppState, AppState>();
+
+            builder.Services.AddLogging(builder => builder
+                .AddBrowserConsole()
+                .SetMinimumLevel(LogLevel.Trace)
+                .AddFilter("Microsoft.AspNetCore.*", level => level >= LogLevel.Information)
+            );
+
             builder.RootComponents.Add<App>("app");
 
             await builder.Build().RunAsync();

--- a/src/Blazor.Gitter.Client/wwwroot/index.html
+++ b/src/Blazor.Gitter.Client/wwwroot/index.html
@@ -1,16 +1,17 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width" />
-	<title>Blazored Gitter - Client Side</title>
-	<base href="/" />
-	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
-	<link href="css/loader.css" rel="stylesheet" />
-	<link href="css/blazored.gitter.min.css" rel="stylesheet" />
-	<link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-	<link rel="icon" href="/favicon.ico" type="image/x-icon">
-	<script src="scripts/chat.js"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Blazored Gitter - Client Side</title>
+    <base href="/" />
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossorigin="anonymous">
+    <link href="css/loader.css" rel="stylesheet" />
+    <link href="css/blazored.gitter.min.css" rel="stylesheet" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <script src="scripts/chat.js"></script>
+    <script src="_content/Blazor.Extensions.Logging/blazor.extensions.logging.js" defer></script>
 </head>
 <body>
 	<app>

--- a/src/Blazor.Gitter.Core/Blazor.Gitter.Core.csproj
+++ b/src/Blazor.Gitter.Core/Blazor.Gitter.Core.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Blazor.Gitter.Core/Components/Shared/AppState.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/AppState.cs
@@ -1,6 +1,7 @@
 ﻿using Blazor.Gitter.Library;
 using Blazored.LocalStorage;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
@@ -16,7 +17,7 @@ namespace Blazor.Gitter.Core.Components.Shared
         private readonly ILocalStorageService LocalStorage;
         private readonly ILocalisationHelper LocalisationHelper;
         private readonly NavigationManager UriHelper;
-
+        private readonly ILogger<AppState> Log;
         private string apiKey;
         private IChatUser myUser;
         private List<IChatRoom> myRooms;
@@ -76,15 +77,16 @@ namespace Blazor.Gitter.Core.Components.Shared
         /// </summary>
         public event EventHandler SearchMenuToggled;
 
-        public AppState(
-            ILocalStorageService localStorage,
-            ILocalisationHelper localisationHelper,
-            NavigationManager uriHelper
-            )
+        public AppState(ILocalStorageService localStorage,
+                        ILocalisationHelper localisationHelper,
+                        NavigationManager uriHelper,
+                        ILogger<AppState> log)
         {
             LocalStorage = localStorage;
             LocalisationHelper = localisationHelper;
             UriHelper = uriHelper;
+            Log = log;
+
             Task.Factory.StartNew(Initialise);
         }
 
@@ -108,7 +110,7 @@ namespace Blazor.Gitter.Core.Components.Shared
                 {
                     if (done == 1)
                     {
-                        Console.WriteLine(ex);
+                        Log.LogError(ex, "Couldn't initialize AppState");
                     }
                 }
 

--- a/src/Blazor.Gitter.Core/Components/Shared/RoomMessages.razor.cs
+++ b/src/Blazor.Gitter.Core/Components/Shared/RoomMessages.razor.cs
@@ -1,6 +1,7 @@
 ﻿using Blazor.Gitter.Core.Browser;
 using Blazor.Gitter.Library;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using System;
 using System.Collections.Generic;
@@ -16,6 +17,7 @@ namespace Blazor.Gitter.Core.Components.Shared
         [Inject] IChatApi GitterApi { get; set; }
         [Inject] ILocalisationHelper Localisation { get; set; }
         [Inject] IAppState State { get; set; }
+        [Inject] ILogger<RoomMessagesBase> Log { get; set; }
 
         [Parameter] public IChatRoom ChatRoom { get; set; }
         [Parameter] public string UserId { get; set; }
@@ -224,9 +226,9 @@ namespace Blazor.Gitter.Core.Components.Shared
                         await Task.Delay(1);
                     }
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Console.WriteLine($"RoomMessages.FetchNewMessages: {e.GetBaseException().Message}");
+                    Log.LogError(ex, "Failed to fetch new room messages");
                 }
                 finally
                 {

--- a/src/Blazor.Gitter.Core/Services/LocalisationHelper.cs
+++ b/src/Blazor.Gitter.Core/Services/LocalisationHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.JSInterop;
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
@@ -10,13 +11,15 @@ namespace Blazor.Gitter.Core
         private TimeZoneInfo localTimeZoneInfo;
         private CultureInfo localCultureInfo;
         private IJSRuntime JSRuntime;
+        private readonly ILogger<ILocalisationHelper> Log;
 
         public TimeZoneInfo LocalTimeZoneInfo => localTimeZoneInfo ?? TimeZoneInfo.Local;
         public CultureInfo LocalCultureInfo => localCultureInfo ?? CultureInfo.CurrentCulture;
 
-        public LocalisationHelper(IJSRuntime jSRuntime)
+        public LocalisationHelper(IJSRuntime jSRuntime, ILogger<ILocalisationHelper> log)
         {
             JSRuntime = jSRuntime;
+            Log = log;
         }
         public async Task BuildLocalTimeZone()
         {
@@ -28,7 +31,7 @@ namespace Blazor.Gitter.Core
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Log.LogError(ex, "Failed to build local time zone");
                 localTimeZoneInfo = TimeZoneInfo.Local;
             }
         }
@@ -41,7 +44,7 @@ namespace Blazor.Gitter.Core
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Log.LogError(ex, "Failed to build local culture info");
                 localCultureInfo = CultureInfo.CurrentCulture;
             }
         }
@@ -54,7 +57,7 @@ namespace Blazor.Gitter.Core
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Log.LogError(ex, "Failed to get key");
                 return string.Empty;
             }
         }

--- a/src/Blazor.Gitter.Core/browser/BrowserInterop.cs
+++ b/src/Blazor.Gitter.Core/browser/BrowserInterop.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using System;
 using System.Threading.Tasks;
@@ -11,7 +12,9 @@ namespace Blazor.Gitter.Core.Browser
         {
             return JSRuntime.InvokeAsync<double>("chat.getScrollTop",id);
         }
-        public static ValueTask<bool> IsScrolledToBottom(this IJSRuntime JSRuntime, string id)
+        public static ValueTask<bool> IsScrolledToBottom(this IJSRuntime JSRuntime,
+                                                         ILogger log,
+                                                         string id)
         {
             try
             {
@@ -19,7 +22,7 @@ namespace Blazor.Gitter.Core.Browser
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"BrowserInterop.IsScrolledToBottom: {ex.GetBaseException().Message}");
+                log.LogError(ex, "BrowserInterop.IsScrolledToBottom failed");
             }
             return new ValueTask<bool>(Task.FromResult(false));
         }

--- a/src/Blazor.Gitter.Library/Blazor.Gitter.Library.csproj
+++ b/src/Blazor.Gitter.Library/Blazor.Gitter.Library.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
   </ItemGroup>
 
 </Project>

--- a/src/Blazor.Gitter.Library/Services/GitterApi.cs
+++ b/src/Blazor.Gitter.Library/Services/GitterApi.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Blazor.Gitter.Library
 {
@@ -16,9 +17,13 @@ namespace Blazor.Gitter.Library
 
         private string Token { get; set; }
         private HttpClient HttpClient { get; set; }
-        public GitterApi(HttpClient httpClient = null)
+
+        private readonly ILogger<GitterApi> Log;
+
+        public GitterApi(HttpClient httpClient = null, ILogger<GitterApi> log = null)
         {
             HttpClient = httpClient ?? throw new Exception("Make sure you have added an HttpClient to your DI Container");
+            Log = log;
         }
 
         public void SetAccessToken(string token)
@@ -41,11 +46,12 @@ namespace Blazor.Gitter.Library
         {
             try
             {
-                Console.WriteLine("Fetching gitter user.");
+                Log.LogDebug("Fetching gitter user.");
                 return (await HttpClient.GetFromJsonAsync<GitterUser[]>(APIUSERPATH)).First();
-            } catch (Exception ex)
+            }
+            catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                Log.LogError(ex, "Failed to fetch gitter user");
                 throw;
             }
         }

--- a/src/Blazor.Gitter.Server/Blazor.Gitter.Server.csproj
+++ b/src/Blazor.Gitter.Server/Blazor.Gitter.Server.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
On the client side, we use Blazor.Extensions.Logging to log to the browser console.

Not yet implemented on the server side.